### PR TITLE
Update dependencies and remove magic number.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-bincode"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Olli Paananen <paananen.olli@tuta.io>"]
 description = "Bincode extractor for Actix Web"
@@ -15,11 +15,11 @@ name = "actix_bincode"
 path = "src/lib.rs"
 
 [dependencies]
-actix-web = "4.2.1"
-bincode = { version = "2.0.0-rc.2", features = ["serde"] }
+actix-web = "4.3.1"
+bincode = { version = "2.0.0-rc.3", features = ["serde"] }
 derive_more = "0.99.17"
-futures = "0.3.25"
-serde = { version = "1.0.151", features = ["derive"] }
+futures = "0.3.28"
+serde = { version = "1.0.174", features = ["derive"] }
 
 [features]
 serde = []

--- a/src/compat/mod.rs
+++ b/src/compat/mod.rs
@@ -7,7 +7,10 @@ use actix_web::{dev::Payload, web::BytesMut, FromRequest, HttpMessage, HttpReque
 use bincode::config::Configuration;
 use futures::{Future, StreamExt};
 
-use crate::{config::BincodeConfig, error::BincodePayloadError};
+use crate::{
+    config::{BincodeConfig, DEFAULT_LIMIT_BYTES},
+    error::BincodePayloadError,
+};
 
 /// Extract and deserialize bincode from payload with serde compatibility
 ///
@@ -46,7 +49,9 @@ where
         }
 
         // Read limit if present
-        let limit = req.app_data::<BincodeConfig>().map_or(262_144, |c| c.limit);
+        let limit = req
+            .app_data::<BincodeConfig>()
+            .map_or(DEFAULT_LIMIT_BYTES, |c| c.limit);
 
         // Read bincode config
         let bincode_config = req

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,9 +11,14 @@
 ///
 #[derive(Clone, Debug)]
 pub struct BincodeConfig {
-    /// Bytes
+    /// The maximum size in bytes of a request payload that can be deserialized.
+    /// By default set to [DEFAULT_LIMIT_BYTES]
     pub limit: usize,
 }
+
+/// The default limit in bytes used when deserializing a request payload.
+/// Set to 256 KiB.
+pub const DEFAULT_LIMIT_BYTES: usize = 262_144; // 256 KiB
 
 #[allow(dead_code)]
 impl BincodeConfig {
@@ -25,8 +30,10 @@ impl BincodeConfig {
 }
 
 impl Default for BincodeConfig {
-    /// Defaults to 256kb
+    /// A default config with limit of 256 KiB.
     fn default() -> Self {
-        BincodeConfig { limit: 262_144 }
+        BincodeConfig {
+            limit: DEFAULT_LIMIT_BYTES,
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ where
         // Read limit if present
         let limit = req
             .app_data::<config::BincodeConfig>()
-            .map_or(262_144, |c| c.limit);
+            .map_or(config::DEFAULT_LIMIT_BYTES, |c| c.limit);
 
         // Read bincode config
         let bincode_config = req


### PR DESCRIPTION
Hello!

This PR updates all dependencies and removes the magic number used for the default deserialization limit.

Changes were formatted and tests as such:
```
cargo fmt
cargo test --all-features 
```